### PR TITLE
Add Docker Build and Push Workflow to GHCR

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,0 +1,76 @@
+name: Push Docker Image to GitHub Container Registry
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - v*
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag'
+        required: true
+        default: 'develop'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    name: Docker Build and Push
+    runs-on: ubuntu-latest
+
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: lowercase the IMAGE_NAME
+        run: echo IMAGE_NAME="${IMAGE_NAME,,}" >> $GITHUB_ENV
+
+      - name: Get Tags
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            TAG=${{ github.event.inputs.tag }}
+          elif [[ $GITHUB_REF == refs/tags/* ]]; then
+            TAG=${GITHUB_REF#refs/tags/}
+          else
+            TAG=${GITHUB_REF#refs/heads/}
+          fi
+          echo "TAG=$TAG" >> "$GITHUB_ENV"
+
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          install: true
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tag Docker image
+        run: |
+          echo "IMAGE_TAG=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.TAG }}" >> "$GITHUB_ENV"
+
+          if [[ ${{ env.TAG }} == v* ]]; then
+            echo "LATEST_TAG=,${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest" >> "$GITHUB_ENV"
+          fi
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ env.IMAGE_TAG }}${{ env.LATEST_TAG }}

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,4 +1,4 @@
-name: Push Docker Image to GitHub Container Registry
+name: Push Docker image to the GitHub Container Registry (GHCR)
 
 on:
   push:
@@ -31,10 +31,10 @@ jobs:
       packages: write
 
     steps:
-      - name: lowercase the IMAGE_NAME
+      - name: Lowercase the image name
         run: echo IMAGE_NAME="${IMAGE_NAME,,}" >> $GITHUB_ENV
 
-      - name: Get Tags
+      - name: Get repository tags
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             TAG=${{ github.event.inputs.tag }}
@@ -45,22 +45,22 @@ jobs:
           fi
           echo "TAG=$TAG" >> "$GITHUB_ENV"
 
-      - name: Check out the repo
+      - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
+      - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
           install: true
 
-      - name: Log in to the Container registry
+      - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Tag Docker image
+      - name: Tag the image
         run: |
           echo "IMAGE_TAG=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.TAG }}" >> "$GITHUB_ENV"
 
@@ -68,7 +68,7 @@ jobs:
             echo "LATEST_TAG=,${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest" >> "$GITHUB_ENV"
           fi
 
-      - name: Build and push Docker image
+      - name: Build and Push the image
         uses: docker/build-push-action@v5
         with:
           context: .

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -41,7 +41,7 @@ jobs:
           elif [[ $GITHUB_REF == refs/tags/* ]]; then
             TAG=${GITHUB_REF#refs/tags/}
           else
-            TAG=${GITHUB_REF#refs/heads/}
+            TAG=latest
           fi
           echo "TAG=$TAG" >> "$GITHUB_ENV"
 

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - feature/add_push-image-registory_-workflow
     tags:
       - v*
   workflow_dispatch:

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - feature/add_push-image-registory_-workflow
     tags:
       - v*
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -49,13 +49,30 @@ If you found this tool useful, consider offering me a coffee using [PayPal](http
 
 ---
 
-## How to install
+## Use with Docker / Docker Compose
+
+If you already have a Docker environment, you can be up and running in minutes using the following command (obviously you need to change the value):
+
+```sh
+docker run -d --name ilo-fans-controller --restart always \
+    -p 8000:80 \
+    -e ILO_HOST='your-ilo-address' \
+    -e ILO_USERNAME='your-ilo-username' \
+    -e ILO_PASSWORD='your-ilo-password' \
+    ghcr.io/alex3025/ilo-fan-controller:latest
+```
+
+Or if you prefer, you can use `docker compose`, as the [docker-compose.yaml](https://github.com/alex3025/ilo-fans-controller/blob/main/docker-compose.yaml) file is provided as well.
+
+---
 
 > ⚠ **IMPORTANT!** ⚠
 >
 > Again, this tool works thanks to a **[patched iLO firmware](#can-i-use-this-tool-with-my-hp-server-%EF%B8%8F)** that expose to the iLO SSH interface some commands to manipulate the fans speeds.
 >
 > **This patch is required to use this tool!**
+
+## Manual installation
 
 ### The following guide was run on
 


### PR DESCRIPTION
This PR is a new GitHub Actions workflow that builds and pushes Docker images to the GitHub Container Registry (GHCR).

This workflow is triggered by a push event to the `main` branch or a tag starting with `v`. It can also be triggered manually on a given tag.

Docker images will be tagged with the Git tag, if present, and if the Git tag starts with `v`, the image will also be tagged with `latest`.

Users can docker pull to launch without doing a docker build themselves.

Sample Packages → https://github.com/NAKNAO-nnct/ilo-fans-controller/pkgs/container/ilo-fans-controller

translated by DeepL